### PR TITLE
Multiple roles that can ping

### DIFF
--- a/app.php
+++ b/app.php
@@ -131,11 +131,9 @@ $app->get('/auth/', function () use ($app, $config, $log) {
                 'guild.id' => $config['discord']['guildId']
             ]);
             foreach ($roles as $role) {
-                if ($role->name == $config['pings']['pingRole']) {
+                if (in_array($role->name, $config['pings']['pingRoles'])) {
                     if (in_array((int)$role->id, $memberRoles)) {
                         $canPing = true;
-                        break;
-                    } else {
                         break;
                     }
                 }

--- a/config/config.new.php
+++ b/config/config.new.php
@@ -46,7 +46,7 @@ $config['groups'] = [
 $config['pings'] = [ // Send announcements to various discord channels
     'enabled' => false,
     'pingChannel' => 0, // Channel ID that pings default to
-    'pingRole' => [''], // Discord roles that can send pings
+    'pingRoles' => [''], // Discord roles that can send pings
     'append' => '=== Ping Sent Via Keepstar Auth ===', // All pings will have this line added to the footer
 ];
 

--- a/config/config.new.php
+++ b/config/config.new.php
@@ -46,7 +46,7 @@ $config['groups'] = [
 $config['pings'] = [ // Send announcements to various discord channels
     'enabled' => false,
     'pingChannel' => 0, // Channel ID that pings default to
-    'pingRole' => '', // Discord role that can send pings
+    'pingRole' => [''], // Discord roles that can send pings
     'append' => '=== Ping Sent Via Keepstar Auth ===', // All pings will have this line added to the footer
 ];
 


### PR DESCRIPTION
Change the pingRole to an array pingRoles in config
Check that the guildMember has at least one of the role in pingRoles to display ping in the dashboard